### PR TITLE
feat: add cloud deployment tui with provider scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+.DS_Store

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,86 @@
+# Cloud Deployment TUI Plan
+
+## Vision and Goals
+- Provide a unified terminal user interface (TUI) for provisioning, listing, and connecting to servers across AWS EC2, Google Cloud Compute Engine, Azure Virtual Machines, and DigitalOcean Droplets.
+- Allow operators to manage reusable SSH keys for future sessions and automatically associate keys with instances.
+- Present provider-agnostic workflows alongside provider specific configuration steps.
+- Use **TypeScript** for implementation and build the TUI on top of the `open-tui` stack (React + tuir renderer) to satisfy the requested technology constraints.
+
+## Functional Scope
+1. **Workspace Overview**
+   - Landing view summarising configured SSH keys and saved deployments per provider.
+   - Quick actions to start new deployments or connect to existing hosts.
+2. **Deployment Wizards**
+   - Provider specific wizards gather minimal parameters (region, machine shape, image, auth key).
+   - Each wizard produces an execution plan containing SDK calls/CLI commands (actual execution pluggable).
+3. **Instance Access**
+   - View active instances retrieved from remote provider (mocked initially, pluggable real implementations).
+   - Trigger SSH connection command (opens `ssh` using stored keys).
+4. **SSH Key Vault**
+   - Secure storage of key metadata and paths (no private key contents stored) under `~/.config/cloud-orchestrator/config.json`.
+   - Import new keys, mark default, associate keys with providers.
+5. **Execution Backends**
+   - Abstraction that can either produce CLI command sequences for manual execution or use cloud SDK APIs.
+   - Provide placeholders for AWS SDK v3, Google Cloud API, Azure SDK, and DigitalOcean API integration.
+
+## Architecture Overview
+```
+src/
+ ├─ index.ts            # Application entrypoint, initializes stores and mounts the TUI
+ ├─ ui/                 # React components rendered via open-tui/tuir
+ │   ├─ App.tsx         # Layout shell and router between screens
+ │   ├─ panes/          # Provider dashboards and forms
+ │   └─ components/     # Reusable UI widgets (lists, forms, modals)
+ ├─ services/
+ │   ├─ deploymentService.ts   # Provider-agnostic orchestration
+ │   ├─ providerClients.ts     # SDK/CLI adaptors per provider
+ │   └─ sshService.ts          # Manage SSH key import, selection, and association
+ ├─ providers/
+ │   ├─ awsProvider.ts
+ │   ├─ gcpProvider.ts
+ │   ├─ azureProvider.ts
+ │   └─ digitalOceanProvider.ts
+ ├─ storage/
+ │   └─ configStore.ts  # File-backed JSON store with schema validation
+ ├─ types/
+ │   └─ index.ts        # Shared types for deployments, keys, instances
+ └─ utils/
+     ├─ logger.ts       # Uniform logging utilities
+     └─ ssh.ts          # Helper utilities for working with SSH keys
+```
+
+## Data Model
+- `SshKeyMetadata`: { id, name, publicKeyPath, privateKeyPath, fingerprint, providers[] }
+- `DeploymentProfile`: { id, provider, name, configuration, status, createdAt, lastUpdated }
+- `InstanceDescriptor`: { id, provider, name, region, ipAddress, state, keyId }
+- Configuration file persists arrays of keys and deployments plus preferences.
+
+## Provider Strategy
+- Each provider module exposes:
+  - `createDeployment(config, sshKey)` → returns `DeploymentPlan` detailing API calls.
+  - `listInstances()` → fetches current compute resources (mocked initial data from config file to avoid credentials).
+  - `connect(instance, key)` → returns the shell command to run `ssh`.
+- The plan executor (future work) may interpret `DeploymentPlan` to perform real operations using official SDKs; scaffolding includes typed placeholders and TODO comments.
+
+## UI Flow
+1. `App` displays summary and menu using open-tui Box/Flex components.
+2. Selecting menu item pushes route in Zustand store.
+3. Forms leverage React state; upon submission they call service layer to persist config and produce plan preview.
+4. Instance list view polls provider service (using React Query) to show states.
+5. SSH key manager view allows import (via path) and calculates fingerprint using `ssh-keygen -lf` (if available) or Node crypto fallback.
+
+## CLI Commands
+- `npm run build` → `tsc`
+- `npm start` → `node dist/index.js`
+- `npm run dev` → `ts-node src/index.ts`
+
+## Testing Strategy
+- Provide targeted unit tests for storage/service layers (future work; not in current scope).
+- Manual QA via dev server to verify navigation and config persistence.
+
+## Future Enhancements
+- Real API integration with credential handling per provider.
+- Support for multi-factor authentication and session caching.
+- Bulk actions for scaling groups and deletion workflows.
+- Integration with infrastructure-as-code templates (Terraform/CloudFormation).
+- Role-based access and audit logging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1842 @@
+{
+  "name": "openssh",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openssh",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@tanstack/react-query": "^5.90.2",
+        "open-tui": "^0.2.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "tuir": "^1.1.3",
+        "uuid": "^13.0.0",
+        "zustand": "^5.0.8"
+      },
+      "devDependencies": {
+        "@types/node": "^24.6.2",
+        "@types/react": "^18.2.46",
+        "@types/react-dom": "^18.2.19",
+        "@types/uuid": "^10.0.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+      "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.13.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.25.tgz",
+      "integrity": "sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
+      "integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "license": "MIT"
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.10",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+      "integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-0.1.0.tgz",
+      "integrity": "sha512-d9PXLEY0v1iJ64xLiQMJ51J128EYHAaOR4yZqQi8aHGfw6KgifM3/Viw1oZZ1GCVmb3gBuyhLyHj0HgR2DhSXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/marked": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
+      "integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open-tui": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/open-tui/-/open-tui-0.2.0.tgz",
+      "integrity": "sha512-K5zyi8r/L24fNIqHOG8bFAjH23DPXteN/26a5BLn1QsgyI4X4AKVNlhoiFdmVsmAKB601zm1ddSoP5HMQBrghg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-query": "^4.36.1",
+        "marked": "^11",
+        "marked-terminal": "^7.3.0",
+        "meow": "^13.0.0",
+        "pino": "^9.6.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "socket.io-client": "^4.8.1",
+        "sonic-boom": "^4.2.0",
+        "tuir": "^1.1.3",
+        "uuid": "^11.1.0",
+        "zustand": "^5.0.3"
+      },
+      "bin": {
+        "open-tui": "dist/cli.js"
+      }
+    },
+    "node_modules/open-tui/node_modules/@tanstack/query-core": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.41.0.tgz",
+      "integrity": "sha512-193R4Jp9hjvlij6LryxrB5Mpbffd2L9PeWh3KlIy/hJV4SkBOfiQZ+jc5qAZLDCrdbkA5FjGj+UoDYw6TcNnyA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/open-tui/node_modules/@tanstack/react-query": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.41.0.tgz",
+      "integrity": "sha512-4/euCZAv8zeaB5P/nQiySzB0JHM3tiraU9KjSvSlJAX7oIE9uPDZlHCkDg/bHYNXewzvsg0FtOMq0VUq8XMMOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "4.41.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/open-tui/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "license": "MIT"
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/pino": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.13.1.tgz",
+      "integrity": "sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slow-redact": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.1.tgz",
+      "integrity": "sha512-NvFvl1GuLZNW4U046Tfi8b26zXo8aBzgCAS2f7yVJR/fArN93mOqSA99cB9uITm92ajSz01bsu1K7SCVVjIMpQ==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tuir": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tuir/-/tuir-1.1.3.tgz",
+      "integrity": "sha512-G+eKL1x6mWbJS4psW3KheLmalJNB2D55GGYTdXXrRz+1DnF29xxBIjs4GfkNbNKnuQ8cA6RcUGsVyVMeN9TDeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "immer": "^10.1.1",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^0.1.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.0.0",
+        "type-fest": "^4.8.3",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.15.0",
+        "xxhashjs": "^0.2.2",
+        "yoga-wasm-web": "^0.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tuir/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/tuir/node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/tuir/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tuir/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xxhashjs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
+      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cuint": "^0.2.2"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yoga-wasm-web": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
+      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
+      "license": "MIT"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "openssh",
+  "version": "1.0.0",
+  "description": "openssh",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "npm run build && node dist/index.js",
+    "dev": "ts-node --esm src/index.tsx"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "@tanstack/react-query": "^5.90.2",
+    "open-tui": "^0.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tuir": "^1.1.3",
+    "uuid": "^13.0.0",
+    "zustand": "^5.0.8"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.2",
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.19",
+    "@types/uuid": "^10.0.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, preserveScreen } from 'tuir';
+import App from './ui/App.js';
+
+preserveScreen();
+
+const instance = render(<App />);
+
+instance.waitUntilExit().catch((error: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error('Application exited with error:', error);
+  process.exit(1);
+});
+
+process.on('SIGINT', () => {
+  instance.unmount();
+  process.exit(0);
+});

--- a/src/providers/awsProvider.ts
+++ b/src/providers/awsProvider.ts
@@ -1,0 +1,105 @@
+import { DeploymentPlan, DeploymentStep, InstanceDescriptor, SshKeyMetadata } from '../types/index.js';
+import { ProviderAdapter, ProviderDeploymentInput } from './providerRegistry.js';
+
+function normalise(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value : fallback;
+}
+
+export class AwsProviderAdapter implements ProviderAdapter {
+  readonly provider = 'aws';
+
+  createDeploymentPlan(input: ProviderDeploymentInput, key?: SshKeyMetadata): DeploymentPlan {
+    const region = normalise(input.configuration.region, 'us-east-1');
+    const instanceType = normalise(input.configuration.instanceType, 't3.micro');
+    const ami = normalise(input.configuration.ami, 'ami-latest');
+    const securityGroup = normalise(
+      input.configuration.securityGroup ?? input.configuration.securityGroupId,
+      `${input.name}-sg`,
+    );
+    const subnetId = typeof input.configuration.subnetId === 'string' ? input.configuration.subnetId : undefined;
+    const volumeSize = typeof input.configuration.volumeSize === 'number'
+      ? input.configuration.volumeSize
+      : Number.parseInt(String(input.configuration.volumeSize ?? ''), 10) || 20;
+    const sshKeyName = normalise(
+      input.configuration.sshKeyName,
+      key?.name ? key.name.replace(/\s+/g, '-') : `${input.name}-key`,
+    );
+    const tags = (input.configuration.tags as Record<string, string> | undefined) ?? {};
+    const userDataPath = typeof input.configuration.userDataPath === 'string'
+      ? input.configuration.userDataPath
+      : undefined;
+
+    const steps: DeploymentStep[] = [];
+
+    if (key) {
+      steps.push({
+        title: 'Ensure EC2 key pair exists',
+        description: 'Import the SSH public key into AWS EC2 so that the instance trusts it.',
+        command: `aws ec2 import-key-pair --key-name ${sshKeyName} --public-key-material "$(cat ${key.publicKeyPath})" --region ${region}`,
+      });
+    }
+
+    steps.push({
+      title: 'Create or validate security group',
+      description: 'Ensure the security group allows SSH (port 22) from trusted CIDRs.',
+      command: `aws ec2 create-security-group --group-name ${securityGroup} --description "SSH access for ${input.name}" --region ${region}`,
+    });
+
+    steps.push({
+      title: 'Authorize SSH ingress',
+      command: `aws ec2 authorize-security-group-ingress --group-name ${securityGroup} --protocol tcp --port 22 --cidr 0.0.0.0/0 --region ${region}`,
+    });
+
+    const runArgs = [
+      'aws ec2 run-instances',
+      `--image-id ${ami}`,
+      `--instance-type ${instanceType}`,
+      `--region ${region}`,
+      `--key-name ${sshKeyName}`,
+      `--security-groups ${securityGroup}`,
+      `--block-device-mappings DeviceName=/dev/sda1,Ebs={VolumeSize=${volumeSize}}`,
+      `--tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${input.name}}${formatTagSpec(tags)}]"`,
+    ];
+
+    if (subnetId) {
+      runArgs.push(`--subnet-id ${subnetId}`);
+    }
+
+    if (userDataPath) {
+      runArgs.push(`--user-data file://${userDataPath}`);
+    }
+
+    steps.push({
+      title: 'Launch EC2 instance',
+      command: runArgs.join(' '),
+    });
+
+    return {
+      id: `${this.provider}-${Date.now()}`,
+      provider: this.provider,
+      summary: `Launch ${input.name} in ${region} using ${instanceType}`,
+      steps,
+    };
+  }
+
+  buildSshCommand(instance: InstanceDescriptor, key?: SshKeyMetadata): string | undefined {
+    if (!instance.ipAddress) {
+      return undefined;
+    }
+    const sshUser = typeof instance.tags?.sshUser === 'string'
+      ? instance.tags?.sshUser
+      : 'ec2-user';
+    const identityArg = key ? `-i ${key.privateKeyPath}` : '';
+    return `ssh ${identityArg} ${sshUser}@${instance.ipAddress}`.trim();
+  }
+}
+
+function formatTagSpec(tags: Record<string, string>): string {
+  const formatted = Object.entries(tags)
+    .map(([Key, Value]) => `{Key=${Key},Value=${Value}}`)
+    .join(',');
+  if (!formatted) {
+    return '';
+  }
+  return `,{Key=Project,Value=CloudOrchestrator},${formatted}`;
+}

--- a/src/providers/azureProvider.ts
+++ b/src/providers/azureProvider.ts
@@ -1,0 +1,103 @@
+import { DeploymentPlan, DeploymentStep, InstanceDescriptor, SshKeyMetadata } from '../types/index.js';
+import { ProviderAdapter, ProviderDeploymentInput } from './providerRegistry.js';
+
+function normalise(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value : fallback;
+}
+
+export class AzureProviderAdapter implements ProviderAdapter {
+  readonly provider = 'azure';
+
+  createDeploymentPlan(input: ProviderDeploymentInput, key?: SshKeyMetadata): DeploymentPlan {
+    const resourceGroup = normalise(input.configuration.resourceGroup, `${input.name}-rg`);
+    const location = normalise(input.configuration.location, 'eastus');
+    const vmSize = normalise(input.configuration.vmSize ?? input.configuration.instanceSize, 'Standard_B2s');
+    const image = normalise(input.configuration.image, 'Ubuntu2204');
+    const adminUser = normalise(input.configuration.adminUser ?? input.configuration.sshUser, 'azureuser');
+    const virtualNetwork = normalise(input.configuration.virtualNetwork ?? input.configuration.vnet, `${input.name}-vnet`);
+    const subnet = normalise(input.configuration.subnet ?? input.configuration.subnetName, `${input.name}-subnet`);
+    const nsg = normalise(input.configuration.networkSecurityGroup ?? input.configuration.nsg, `${input.name}-nsg`);
+    const tags = buildTagString(input.configuration.tags as Record<string, string> | undefined);
+
+    const steps: DeploymentStep[] = [];
+
+    steps.push({
+      title: 'Create or update resource group',
+      command: `az group create --name ${resourceGroup} --location ${location}`,
+    });
+
+    steps.push({
+      title: 'Ensure virtual network exists',
+      command: `az network vnet create --resource-group ${resourceGroup} --name ${virtualNetwork} --address-prefix 10.0.0.0/16 --subnet-name ${subnet} --subnet-prefix 10.0.0.0/24`,
+    });
+
+    steps.push({
+      title: 'Configure network security group for SSH',
+      command: `az network nsg create --resource-group ${resourceGroup} --name ${nsg}`,
+    });
+
+    steps.push({
+      title: 'Allow SSH inbound traffic',
+      command: `az network nsg rule create --resource-group ${resourceGroup} --nsg-name ${nsg} --name AllowSSH --priority 1000 --access Allow --protocol Tcp --direction Inbound --source-address-prefixes '*' --source-port-ranges '*' --destination-port-ranges 22`,
+    });
+
+    const vmCommand = [
+      'az vm create',
+      `--resource-group ${resourceGroup}`,
+      `--name ${input.name}`,
+      `--image ${image}`,
+      `--size ${vmSize}`,
+      `--admin-username ${adminUser}`,
+      `--nsg ${nsg}`,
+      `--vnet-name ${virtualNetwork}`,
+      `--subnet ${subnet}`,
+      '--public-ip-sku Standard',
+    ];
+
+    if (key) {
+      vmCommand.push(`--ssh-key-values "$(cat ${key.publicKeyPath})"`);
+    }
+
+    if (tags) {
+      vmCommand.push(`--tags ${tags}`);
+    }
+
+    const customData = typeof input.configuration.cloudInitPath === 'string'
+      ? input.configuration.cloudInitPath
+      : undefined;
+
+    if (customData) {
+      vmCommand.push(`--custom-data ${customData}`);
+    }
+
+    steps.push({
+      title: 'Provision Azure VM',
+      command: vmCommand.join(' '),
+    });
+
+    return {
+      id: `${this.provider}-${Date.now()}`,
+      provider: this.provider,
+      summary: `Provision ${input.name} (${vmSize}) in ${location}`,
+      steps,
+    };
+  }
+
+  buildSshCommand(instance: InstanceDescriptor, key?: SshKeyMetadata): string | undefined {
+    if (!instance.ipAddress) {
+      return undefined;
+    }
+    const user = instance.tags?.adminUser ?? 'azureuser';
+    const identityArg = key ? `-i ${key.privateKeyPath}` : '';
+    return `ssh ${identityArg} ${user}@${instance.ipAddress}`.trim();
+  }
+}
+
+function buildTagString(tags: Record<string, string> | undefined): string | undefined {
+  if (!tags) {
+    return undefined;
+  }
+  return Object.entries(tags)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(' ');
+}

--- a/src/providers/digitalOceanProvider.ts
+++ b/src/providers/digitalOceanProvider.ts
@@ -1,0 +1,80 @@
+import { DeploymentPlan, DeploymentStep, InstanceDescriptor, SshKeyMetadata } from '../types/index.js';
+import { ProviderAdapter, ProviderDeploymentInput } from './providerRegistry.js';
+
+function normalise(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value : fallback;
+}
+
+export class DigitalOceanProviderAdapter implements ProviderAdapter {
+  readonly provider = 'digitalocean';
+
+  createDeploymentPlan(input: ProviderDeploymentInput, key?: SshKeyMetadata): DeploymentPlan {
+    const region = normalise(input.configuration.region, 'nyc1');
+    const size = normalise(input.configuration.size ?? input.configuration.machineType, 's-1vcpu-1gb');
+    const image = normalise(input.configuration.image, 'ubuntu-22-04-x64');
+    const sshKeyName = normalise(input.configuration.sshKeyName, key?.name ?? `${input.name}-key`);
+    const tags = (input.configuration.tags as string[] | undefined) ?? ['managed'];
+    const backups = Boolean(input.configuration.backups);
+    const monitoring = input.configuration.monitoring === undefined ? true : Boolean(input.configuration.monitoring);
+
+    const steps: DeploymentStep[] = [];
+
+    if (key) {
+      steps.push({
+        title: 'Import SSH key into DigitalOcean account',
+        command: `doctl compute ssh-key import ${sshKeyName} --public-key-file ${key.publicKeyPath}`,
+      });
+    }
+
+    const dropletCommand = [
+      'doctl compute droplet create',
+      input.name,
+      `--region ${region}`,
+      `--size ${size}`,
+      `--image ${image}`,
+      `--tag-name ${tags.join(' --tag-name ')}`,
+    ];
+
+    if (key) {
+      const keyReference = key.fingerprint ?? key.name;
+      dropletCommand.push(`--ssh-keys ${keyReference}`);
+    } else if (input.configuration.sshKeyId) {
+      dropletCommand.push(`--ssh-keys ${input.configuration.sshKeyId}`);
+    }
+
+    if (backups) {
+      dropletCommand.push('--enable-backups');
+    }
+    if (monitoring) {
+      dropletCommand.push('--enable-monitoring');
+    }
+
+    const userData = typeof input.configuration.userDataPath === 'string'
+      ? input.configuration.userDataPath
+      : undefined;
+    if (userData) {
+      dropletCommand.push(`--user-data-file ${userData}`);
+    }
+
+    steps.push({
+      title: 'Create DigitalOcean droplet',
+      command: dropletCommand.join(' '),
+    });
+
+    return {
+      id: `${this.provider}-${Date.now()}`,
+      provider: this.provider,
+      summary: `Launch droplet ${input.name} (${size}) in ${region}`,
+      steps,
+    };
+  }
+
+  buildSshCommand(instance: InstanceDescriptor, key?: SshKeyMetadata): string | undefined {
+    if (!instance.ipAddress) {
+      return undefined;
+    }
+    const user = instance.tags?.sshUser ?? 'root';
+    const identityArg = key ? `-i ${key.privateKeyPath}` : '';
+    return `ssh ${identityArg} ${user}@${instance.ipAddress}`.trim();
+  }
+}

--- a/src/providers/gcpProvider.ts
+++ b/src/providers/gcpProvider.ts
@@ -1,0 +1,104 @@
+import { DeploymentPlan, DeploymentStep, InstanceDescriptor, SshKeyMetadata } from '../types/index.js';
+import { ProviderAdapter, ProviderDeploymentInput } from './providerRegistry.js';
+
+function normalise(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value : fallback;
+}
+
+export class GcpProviderAdapter implements ProviderAdapter {
+  readonly provider = 'gcp';
+
+  createDeploymentPlan(input: ProviderDeploymentInput, key?: SshKeyMetadata): DeploymentPlan {
+    const project = normalise(input.configuration.projectId, 'my-gcp-project');
+    const zone = normalise(input.configuration.zone, 'us-central1-a');
+    const machineType = normalise(input.configuration.machineType, 'e2-medium');
+    const imageFamily = normalise(input.configuration.imageFamily, 'debian-12');
+    const imageProject = normalise(input.configuration.imageProject, 'debian-cloud');
+    const network = normalise(input.configuration.network ?? input.configuration.networkInterface, 'default');
+    const subnetwork = typeof input.configuration.subnetwork === 'string'
+      ? input.configuration.subnetwork
+      : undefined;
+    const serviceAccount = typeof input.configuration.serviceAccount === 'string'
+      ? input.configuration.serviceAccount
+      : 'default';
+    const tags = (input.configuration.tags as string[] | undefined) ?? ['ssh'];
+    const metadata = buildMetadata(key, input);
+
+    const steps: DeploymentStep[] = [];
+
+    if (key) {
+      steps.push({
+        title: 'Add SSH key metadata to project',
+        description: 'Ensure the instance metadata includes the SSH public key for OS Login or direct login.',
+        command: `gcloud compute project-info add-metadata --project=${project} --metadata "ssh-keys=${buildGcpMetadataEntry(key)}"`,
+      });
+    }
+
+    const createParts = [
+      'gcloud compute instances create',
+      input.name,
+      `--project=${project}`,
+      `--zone=${zone}`,
+      `--machine-type=${machineType}`,
+      `--image-family=${imageFamily}`,
+      `--image-project=${imageProject}`,
+      `--network=${network}`,
+      `--tags=${tags.join(',')}`,
+      `--service-account=${serviceAccount}`,
+    ];
+
+    if (subnetwork) {
+      createParts.push(`--subnet=${subnetwork}`);
+    }
+
+    if (metadata) {
+      createParts.push(`--metadata=${metadata}`);
+    }
+
+    steps.push({
+      title: 'Provision Compute Engine VM',
+      command: createParts.join(' '),
+    });
+
+    return {
+      id: `${this.provider}-${Date.now()}`,
+      provider: this.provider,
+      summary: `Launch ${input.name} in ${zone} (${machineType})`,
+      steps,
+    };
+  }
+
+  buildSshCommand(instance: InstanceDescriptor, key?: SshKeyMetadata): string | undefined {
+    if (!instance.name) {
+      return undefined;
+    }
+    const zone = instance.tags?.zone ?? 'us-central1-a';
+    const project = instance.tags?.projectId ?? 'my-gcp-project';
+    const identityArg = key ? `-i ${key.privateKeyPath}` : '';
+    return `gcloud compute ssh ${identityArg} ${instance.name} --project=${project} --zone=${zone}`.trim();
+  }
+}
+
+function buildMetadata(key: SshKeyMetadata | undefined, input: ProviderDeploymentInput): string | undefined {
+  const metadataEntries: string[] = [];
+  if (key) {
+    metadataEntries.push(`ssh-keys=${buildGcpMetadataEntry(key)}`);
+  }
+  const userMetadata = input.configuration.metadata as Record<string, string> | undefined;
+  if (userMetadata) {
+    metadataEntries.push(
+      Object.entries(userMetadata)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(','),
+    );
+  }
+  if (metadataEntries.length === 0) {
+    return undefined;
+  }
+  return metadataEntries.join(',');
+}
+
+function buildGcpMetadataEntry(key: SshKeyMetadata): string {
+  const username = key.name.replace(/[^a-zA-Z0-9_-]/g, '').toLowerCase() || 'clouduser';
+  return `${username}:$(cat ${key.publicKeyPath})`;
+}

--- a/src/providers/providerRegistry.ts
+++ b/src/providers/providerRegistry.ts
@@ -1,0 +1,38 @@
+import { DeploymentPlan, InstanceDescriptor, SshKeyMetadata } from '../types/index.js';
+import { AwsProviderAdapter } from './awsProvider.js';
+import { GcpProviderAdapter } from './gcpProvider.js';
+import { AzureProviderAdapter } from './azureProvider.js';
+import { DigitalOceanProviderAdapter } from './digitalOceanProvider.js';
+
+export interface ProviderDeploymentInput {
+  name: string;
+  configuration: Record<string, unknown>;
+}
+
+export interface ProviderAdapter {
+  readonly provider: string;
+  createDeploymentPlan(
+    input: ProviderDeploymentInput,
+    key?: SshKeyMetadata,
+  ): DeploymentPlan;
+  buildSshCommand(instance: InstanceDescriptor, key?: SshKeyMetadata): string | undefined;
+}
+
+const adapters: ProviderAdapter[] = [
+  new AwsProviderAdapter(),
+  new GcpProviderAdapter(),
+  new AzureProviderAdapter(),
+  new DigitalOceanProviderAdapter(),
+];
+
+export function getProviderAdapter(provider: string): ProviderAdapter {
+  const adapter = adapters.find((item) => item.provider === provider);
+  if (!adapter) {
+    throw new Error(`Unsupported provider: ${provider}`);
+  }
+  return adapter;
+}
+
+export function listProviderAdapters(): ProviderAdapter[] {
+  return adapters;
+}

--- a/src/services/deploymentService.ts
+++ b/src/services/deploymentService.ts
@@ -1,0 +1,121 @@
+import { v4 as uuid } from 'uuid';
+import { loadConfig, updateConfig } from '../storage/configStore.js';
+import {
+  CloudProvider,
+  DeploymentPlan,
+  DeploymentProfile,
+  DeploymentStatus,
+  InstanceDescriptor,
+  SshKeyMetadata,
+} from '../types/index.js';
+import { getProviderAdapter, ProviderDeploymentInput } from '../providers/providerRegistry.js';
+import { findDefaultKey, listSshKeys } from './sshService.js';
+
+export interface CreateDeploymentInput {
+  provider: CloudProvider;
+  name: string;
+  configuration: Record<string, unknown>;
+  sshKeyId?: string;
+}
+
+export interface CreateDeploymentResult {
+  profile: DeploymentProfile;
+  plan: DeploymentPlan;
+  sshKey?: SshKeyMetadata;
+}
+
+export async function listDeployments(): Promise<DeploymentProfile[]> {
+  const config = await loadConfig();
+  return config.deployments;
+}
+
+export async function listInstances(): Promise<InstanceDescriptor[]> {
+  const config = await loadConfig();
+  return config.instances;
+}
+
+export async function createDeploymentProfile(input: CreateDeploymentInput): Promise<CreateDeploymentResult> {
+  const allKeys = await listSshKeys();
+  const sshKey = allKeys.find((key) => key.id === input.sshKeyId);
+  const resolvedKey = sshKey ?? (await findDefaultKey(input.provider));
+
+  const baseProfile: DeploymentProfile = {
+    id: uuid(),
+    provider: input.provider,
+    name: input.name,
+    configuration: input.configuration,
+    status: 'planned',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  const profile: DeploymentProfile = resolvedKey
+    ? { ...baseProfile, sshKeyId: resolvedKey.id }
+    : baseProfile;
+
+  const adapter = getProviderAdapter(input.provider);
+  const planInput: ProviderDeploymentInput = {
+    name: input.name,
+    configuration: input.configuration,
+  };
+  const plan = adapter.createDeploymentPlan(planInput, resolvedKey);
+
+  await updateConfig((config) => ({
+    ...config,
+    deployments: [...config.deployments, profile],
+  }));
+
+  if (resolvedKey) {
+    return { profile, plan, sshKey: resolvedKey };
+  }
+
+  return { profile, plan };
+}
+
+export async function updateDeploymentStatus(
+  deploymentId: string,
+  status: DeploymentStatus,
+): Promise<DeploymentProfile | undefined> {
+  let updatedProfile: DeploymentProfile | undefined;
+  await updateConfig((config) => {
+    const deployments = config.deployments.map((deployment) => {
+      if (deployment.id === deploymentId) {
+        updatedProfile = {
+          ...deployment,
+          status,
+          updatedAt: new Date().toISOString(),
+        };
+        return updatedProfile;
+      }
+      return deployment;
+    });
+
+    return {
+      ...config,
+      deployments,
+    };
+  });
+
+  return updatedProfile;
+}
+
+export async function registerInstance(instance: InstanceDescriptor): Promise<void> {
+  await updateConfig((config) => {
+    const others = config.instances.filter((item) => item.id !== instance.id);
+    return {
+      ...config,
+      instances: [...others, instance],
+    };
+  });
+}
+
+export async function buildSshCommandForInstance(instanceId: string): Promise<string | undefined> {
+  const config = await loadConfig();
+  const instance = config.instances.find((item) => item.id === instanceId);
+  if (!instance) {
+    return undefined;
+  }
+  const key = config.sshKeys.find((item) => item.id === instance.sshKeyId) ?? (await findDefaultKey(instance.provider));
+  const adapter = getProviderAdapter(instance.provider);
+  return adapter.buildSshCommand(instance, key);
+}

--- a/src/services/sshService.ts
+++ b/src/services/sshService.ts
@@ -1,0 +1,89 @@
+import { v4 as uuid } from 'uuid';
+import { updateConfig, loadConfig } from '../storage/configStore.js';
+import { CloudProvider, SshKeyMetadata } from '../types/index.js';
+import { calculateFingerprint } from '../utils/ssh.js';
+
+export async function listSshKeys(): Promise<SshKeyMetadata[]> {
+  const config = await loadConfig();
+  return config.sshKeys;
+}
+
+export interface AddSshKeyInput {
+  name: string;
+  publicKeyPath: string;
+  privateKeyPath: string;
+  providers: CloudProvider[];
+}
+
+export async function addSshKey(input: AddSshKeyInput): Promise<SshKeyMetadata> {
+  const fingerprint = await calculateFingerprint(input.publicKeyPath);
+  const key: SshKeyMetadata = {
+    id: uuid(),
+    name: input.name,
+    publicKeyPath: input.publicKeyPath,
+    privateKeyPath: input.privateKeyPath,
+    providers: input.providers,
+    createdAt: new Date().toISOString(),
+    ...(fingerprint ? { fingerprint } : {}),
+  };
+
+  await updateConfig((config) => ({
+    ...config,
+    sshKeys: [...config.sshKeys, key],
+  }));
+
+  return key;
+}
+
+export async function removeSshKey(id: string): Promise<void> {
+  await updateConfig((config) => ({
+    ...config,
+    sshKeys: config.sshKeys.filter((key) => key.id !== id),
+    deployments: config.deployments.map((deployment) => {
+      if (deployment.sshKeyId !== id) {
+        return deployment;
+      }
+      const next = { ...deployment };
+      delete next.sshKeyId;
+      return next;
+    }),
+    instances: config.instances.map((instance) => {
+      if (instance.sshKeyId !== id) {
+        return instance;
+      }
+      const next = { ...instance };
+      delete next.sshKeyId;
+      return next;
+    }),
+  }));
+}
+
+export async function setDefaultKeyForProvider(
+  keyId: string,
+  provider: CloudProvider,
+): Promise<void> {
+  await updateConfig((config) => ({
+    ...config,
+    sshKeys: config.sshKeys.map((key) => {
+      const defaults = new Set(key.defaultFor ?? []);
+      if (key.id === keyId) {
+        defaults.add(provider);
+      } else {
+        defaults.delete(provider);
+      }
+      return {
+        ...key,
+        defaultFor: Array.from(defaults),
+      };
+    }),
+  }));
+}
+
+export async function findDefaultKey(provider: CloudProvider): Promise<SshKeyMetadata | undefined> {
+  const config = await loadConfig();
+  const exact = config.sshKeys.find((key) => key.defaultFor?.includes(provider));
+  if (exact) {
+    return exact;
+  }
+  return config.sshKeys.find((key) => key.providers.includes(provider));
+}

--- a/src/storage/configStore.ts
+++ b/src/storage/configStore.ts
@@ -1,0 +1,59 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { OrchestratorConfig } from '../types/index.js';
+
+const CONFIG_DIR = path.join(os.homedir(), '.config', 'cloud-orchestrator');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
+
+const DEFAULT_CONFIG: OrchestratorConfig = {
+  version: 1,
+  sshKeys: [],
+  deployments: [],
+  instances: [],
+};
+
+async function ensureConfigDir(): Promise<void> {
+  await fs.mkdir(CONFIG_DIR, { recursive: true });
+}
+
+export async function loadConfig(): Promise<OrchestratorConfig> {
+  await ensureConfigDir();
+  try {
+    const raw = await fs.readFile(CONFIG_FILE, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<OrchestratorConfig>;
+    return {
+      ...DEFAULT_CONFIG,
+      ...parsed,
+      version: parsed.version ?? DEFAULT_CONFIG.version,
+      sshKeys: parsed.sshKeys ?? [],
+      deployments: parsed.deployments ?? [],
+      instances: parsed.instances ?? [],
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      await saveConfig(DEFAULT_CONFIG);
+      return DEFAULT_CONFIG;
+    }
+    throw error;
+  }
+}
+
+export async function saveConfig(config: OrchestratorConfig): Promise<void> {
+  await ensureConfigDir();
+  const serialised = JSON.stringify(config, null, 2);
+  await fs.writeFile(CONFIG_FILE, serialised, 'utf-8');
+}
+
+export async function updateConfig(
+  updater: (config: OrchestratorConfig) => OrchestratorConfig,
+): Promise<OrchestratorConfig> {
+  const current = await loadConfig();
+  const updated = updater(current);
+  await saveConfig(updated);
+  return updated;
+}
+
+export function getConfigFilePath(): string {
+  return CONFIG_FILE;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,69 @@
+export type CloudProvider = 'aws' | 'gcp' | 'azure' | 'digitalocean';
+
+export interface SshKeyMetadata {
+  id: string;
+  name: string;
+  publicKeyPath: string;
+  privateKeyPath: string;
+  fingerprint?: string;
+  providers: CloudProvider[];
+  defaultFor?: CloudProvider[];
+  createdAt: string;
+}
+
+export type DeploymentStatus = 'draft' | 'planned' | 'provisioning' | 'provisioned' | 'failed';
+
+export interface DeploymentProfile {
+  id: string;
+  provider: CloudProvider;
+  name: string;
+  configuration: Record<string, unknown>;
+  status: DeploymentStatus;
+  sshKeyId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DeploymentStep {
+  title: string;
+  description?: string;
+  command?: string;
+  apiCall?: {
+    service: string;
+    action: string;
+    payload: Record<string, unknown>;
+  };
+}
+
+export interface DeploymentPlan {
+  id: string;
+  provider: CloudProvider;
+  steps: DeploymentStep[];
+  summary: string;
+}
+
+export interface InstanceDescriptor {
+  id: string;
+  provider: CloudProvider;
+  name: string;
+  region: string;
+  ipAddress?: string;
+  state: 'pending' | 'running' | 'stopped' | 'terminated' | 'unknown';
+  sshKeyId?: string;
+  profileId?: string;
+  tags?: Record<string, string>;
+  createdAt?: string;
+}
+
+export interface OrchestratorConfig {
+  version: number;
+  sshKeys: SshKeyMetadata[];
+  deployments: DeploymentProfile[];
+  instances: InstanceDescriptor[];
+}
+
+export interface ProviderContext {
+  provider: CloudProvider;
+  profiles: DeploymentProfile[];
+  instances: InstanceDescriptor[];
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,0 +1,573 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  Text,
+  Viewport,
+  useApp,
+  useInput,
+  Spacer,
+} from 'tuir';
+type InputKey = {
+  ctrl?: boolean;
+  return?: boolean;
+  esc?: boolean;
+  backspace?: boolean;
+  tab?: boolean;
+  up?: boolean;
+  down?: boolean;
+  left?: boolean;
+  right?: boolean;
+};
+import { parseCommandLine } from '../utils/commandParser.js';
+import { addSshKey, listSshKeys, removeSshKey, setDefaultKeyForProvider } from '../services/sshService.js';
+import {
+  buildSshCommandForInstance,
+  createDeploymentProfile,
+  listDeployments,
+  listInstances,
+  registerInstance,
+  updateDeploymentStatus,
+} from '../services/deploymentService.js';
+import { CloudProvider, DeploymentProfile, InstanceDescriptor, SshKeyMetadata } from '../types/index.js';
+
+interface Message {
+  text: string;
+  level: 'info' | 'success' | 'error';
+}
+
+const PANELS = ['deployments', 'instances', 'sshKeys'] as const;
+type Panel = (typeof PANELS)[number];
+
+type IndexState = Record<Panel, number>;
+
+const HELP_TEXT = [
+  'Commands:',
+  '  help                                 Show this message',
+  '  refresh                              Reload data from disk',
+  '  add-key --name NAME --public PATH --private PATH --providers aws,gcp,... [--default-for PROVIDER]',
+  '  remove-key KEY_ID',
+  '  default-key PROVIDER KEY_ID',
+  '  create-deployment --provider PROVIDER --name NAME [--key KEY_ID] [--region REGION] [...]',
+  '     Use --config.KEY VALUE to provide arbitrary configuration entries.',
+  '  status DEPLOYMENT_ID STATUS           Update deployment status',
+  '  register-instance --id ID --provider PROVIDER --name NAME --region REGION --ip ADDRESS [--state STATE] [--key KEY_ID]',
+  '  ssh-command INSTANCE_ID               Display SSH command for an instance',
+  'Enter command mode by pressing : and exit with Esc.',
+];
+
+export function App(): React.ReactNode {
+  const app = useApp();
+  const [deployments, setDeployments] = useState<DeploymentProfile[]>([]);
+  const [instances, setInstances] = useState<InstanceDescriptor[]>([]);
+  const [sshKeys, setSshKeys] = useState<SshKeyMetadata[]>([]);
+  const [selectedPanelIndex, setSelectedPanelIndex] = useState<number>(0);
+  const [selectedIndices, setSelectedIndices] = useState<IndexState>({
+    deployments: 0,
+    instances: 0,
+    sshKeys: 0,
+  });
+  const [messages, setMessages] = useState<Message[]>([{
+    text: 'Press : to open the command palette. Use arrow keys to navigate panels.',
+    level: 'info',
+  }]);
+  const [commandMode, setCommandMode] = useState(false);
+  const [commandBuffer, setCommandBuffer] = useState('');
+
+  const pushMessage = useCallback((text: string, level: Message['level'] = 'info') => {
+    setMessages((prev) => {
+      const next = [...prev, { text, level }];
+      return next.slice(-12);
+    });
+  }, []);
+
+  const refreshData = useCallback(async () => {
+    try {
+      const [nextDeployments, nextInstances, nextKeys] = await Promise.all([
+        listDeployments(),
+        listInstances(),
+        listSshKeys(),
+      ]);
+      setDeployments(nextDeployments);
+      setInstances(nextInstances);
+      setSshKeys(nextKeys);
+      setSelectedIndices((prev) => ({
+        deployments: clampIndex(prev.deployments, nextDeployments.length),
+        instances: clampIndex(prev.instances, nextInstances.length),
+        sshKeys: clampIndex(prev.sshKeys, nextKeys.length),
+      }));
+    } catch (error) {
+      pushMessage(`Failed to refresh data: ${(error as Error).message}`, 'error');
+    }
+  }, [pushMessage]);
+
+  useEffect(() => {
+    void refreshData();
+  }, [refreshData]);
+
+  const handleCommand = useCallback(async (raw: string) => {
+    const parsed = parseCommandLine(raw);
+    if (!parsed) {
+      return;
+    }
+
+    const { command, args, options } = parsed;
+    try {
+      switch (command) {
+        case 'help':
+          HELP_TEXT.forEach((line) => pushMessage(line));
+          break;
+        case 'refresh':
+          await refreshData();
+          pushMessage('Data refreshed.', 'success');
+          break;
+        case 'add-key': {
+          const name = String(options.name ?? options.n ?? '');
+          const publicKeyPath = String(options.public ?? options.pub ?? '');
+          const privateKeyPath = String(options.private ?? options.pri ?? '');
+          const providersValue = String(options.providers ?? options.provider ?? '');
+          if (!name || !publicKeyPath || !privateKeyPath || !providersValue) {
+            throw new Error('name, public, private, and providers options are required.');
+          }
+          const providers = providersValue.split(',').map((item) => item.trim()).filter(Boolean) as CloudProvider[];
+          const key = await addSshKey({
+            name,
+            publicKeyPath,
+            privateKeyPath,
+            providers,
+          });
+          if (options['default-for']) {
+            const provider = options['default-for'];
+            await setDefaultKeyForProvider(key.id, provider as CloudProvider);
+          }
+          await refreshData();
+          pushMessage(`SSH key ${key.name} added.`, 'success');
+          break;
+        }
+        case 'remove-key': {
+          const keyId = args[0] ?? String(options.id ?? '');
+          if (!keyId) {
+            throw new Error('Key ID is required.');
+          }
+          await removeSshKey(keyId);
+          await refreshData();
+          pushMessage(`Removed SSH key ${keyId}.`, 'success');
+          break;
+        }
+        case 'default-key': {
+          const provider = (args[0] ?? options.provider) as CloudProvider | undefined;
+          const keyId = args[1] ?? String(options.key ?? '');
+          if (!provider || !keyId) {
+            throw new Error('Usage: default-key <provider> <keyId>');
+          }
+          await setDefaultKeyForProvider(keyId, provider);
+          await refreshData();
+          pushMessage(`Set key ${keyId} as default for ${provider}.`, 'success');
+          break;
+        }
+        case 'create-deployment': {
+          const provider = (options.provider ?? options.p ?? '') as CloudProvider;
+          const name = String(options.name ?? options.n ?? '');
+          if (!provider || !name) {
+            throw new Error('provider and name options are required.');
+          }
+          const configuration = buildConfiguration(options);
+          const deploymentInput = {
+            provider,
+            name,
+            configuration,
+            ...(options.key ? { sshKeyId: String(options.key) } : {}),
+          };
+          const result = await createDeploymentProfile(deploymentInput);
+          await refreshData();
+          pushMessage(`Deployment plan created for ${name}.`, 'success');
+          pushMessage(`Plan summary: ${result.plan.summary}`);
+          result.plan.steps.forEach((step, index) => {
+            const commandText = step.command ? ` → ${step.command}` : step.description ? ` → ${step.description}` : '';
+            pushMessage(` ${index + 1}. ${step.title}${commandText}`);
+          });
+          break;
+        }
+        case 'status': {
+          const deploymentId = args[0];
+          const status = args[1];
+          if (!deploymentId || !status) {
+            throw new Error('Usage: status <deploymentId> <status>');
+          }
+          await updateDeploymentStatus(deploymentId, status as any);
+          await refreshData();
+          pushMessage(`Deployment ${deploymentId} updated to ${status}.`, 'success');
+          break;
+        }
+        case 'register-instance': {
+          const provider = (options.provider ?? options.p ?? '') as CloudProvider;
+          const id = String(options.id ?? args[0] ?? '');
+          const name = String(options.name ?? options.n ?? '');
+          const region = String(options.region ?? options.r ?? '');
+          const ipAddress = options.ip ? String(options.ip) : undefined;
+          const state = options.state ? String(options.state) : 'running';
+          const sshKeyId = options.key ? String(options.key) : undefined;
+          if (!id || !provider || !name || !region) {
+            throw new Error('id, provider, name, and region options are required.');
+          }
+          const instanceRecord: InstanceDescriptor = {
+            id,
+            provider,
+            name,
+            region,
+            state: state as InstanceDescriptor['state'],
+            createdAt: new Date().toISOString(),
+            ...(ipAddress ? { ipAddress } : {}),
+            ...(sshKeyId ? { sshKeyId } : {}),
+          };
+          await registerInstance(instanceRecord);
+          await refreshData();
+          pushMessage(`Instance ${id} registered.`, 'success');
+          break;
+        }
+        case 'ssh-command': {
+          const instanceId = args[0] ?? String(options.id ?? '');
+          if (!instanceId) {
+            throw new Error('Instance ID is required.');
+          }
+          const commandLine = await buildSshCommandForInstance(instanceId);
+          if (!commandLine) {
+            pushMessage(`Unable to build SSH command for ${instanceId}.`, 'error');
+          } else {
+            pushMessage(`SSH command: ${commandLine}`);
+          }
+          break;
+        }
+        default:
+          pushMessage(`Unknown command: ${command}`, 'error');
+          break;
+      }
+    } catch (error) {
+      pushMessage(`Command error: ${(error as Error).message}`, 'error');
+    }
+  }, [pushMessage, refreshData]);
+
+  useInput((input: string, key: InputKey) => {
+    if (key.ctrl && input === 'c') {
+      app.exit();
+      return;
+    }
+
+    if (commandMode) {
+      if (key.return) {
+        const trimmed = commandBuffer.trim();
+        if (trimmed.length > 0) {
+          void handleCommand(trimmed);
+        }
+        setCommandBuffer('');
+        setCommandMode(false);
+        return;
+      }
+      if (key.esc) {
+        setCommandMode(false);
+        setCommandBuffer('');
+        return;
+      }
+      if (key.backspace) {
+        setCommandBuffer((prev) => prev.slice(0, -1));
+        return;
+      }
+      if (input && !key.return && !key.tab) {
+        setCommandBuffer((prev) => prev + input);
+      }
+      return;
+    }
+
+    if (input === ':') {
+      setCommandMode(true);
+      setCommandBuffer('');
+      return;
+    }
+
+    const panelId = PANELS[selectedPanelIndex] ?? PANELS[0];
+
+    if (key.left) {
+      setSelectedPanelIndex((prev) => (prev - 1 + PANELS.length) % PANELS.length);
+      return;
+    }
+    if (key.right) {
+      setSelectedPanelIndex((prev) => (prev + 1) % PANELS.length);
+      return;
+    }
+    if (key.up || input === 'k') {
+      setSelectedIndices((prev) => {
+        const next = { ...prev };
+        const current = next[panelId];
+        next[panelId] = current > 0 ? current - 1 : current;
+        return next;
+      });
+      return;
+    }
+    if (key.down || input === 'j') {
+      const length = getPanelLength(panelId, deployments, instances, sshKeys);
+      setSelectedIndices((prev) => {
+        const next = { ...prev };
+        const current = next[panelId];
+        next[panelId] = current + 1 < length ? current + 1 : current;
+        return next;
+      });
+    }
+  }, {
+    isActive: true,
+  });
+
+  const menuHighlight = selectedPanelIndex;
+  const panelSummaries = useMemo(() => ({
+    deployments: deployments.length === 0
+      ? 'No deployment plans yet.'
+      : `${deployments.length} plans` ,
+    instances: instances.length === 0 ? 'No instances tracked.' : `${instances.length} instances`,
+    sshKeys: sshKeys.length === 0 ? 'No SSH keys stored.' : `${sshKeys.length} keys`,
+  }), [deployments.length, instances.length, sshKeys.length]);
+
+  return (
+    <Viewport>
+      <Box flexDirection="column" height="100%" width="100%" padding={1} gap={1}>
+        <Box flexDirection="row" gap={1} flexGrow={1}>
+          <PanelView
+            title="Deployments"
+            isActive={menuHighlight === 0}
+            summary={panelSummaries.deployments}
+            items={deployments.map((deployment) => `${deployment.name} (${deployment.provider}) - ${deployment.status}`)}
+            selectedIndex={selectedIndices.deployments}
+          />
+          <PanelView
+            title="Instances"
+            isActive={menuHighlight === 1}
+            summary={panelSummaries.instances}
+            items={instances.map((instance) => formatInstanceRow(instance))}
+            selectedIndex={selectedIndices.instances}
+          />
+          <PanelView
+            title="SSH Keys"
+            isActive={menuHighlight === 2}
+            summary={panelSummaries.sshKeys}
+            items={sshKeys.map((key) => formatKeyRow(key))}
+            selectedIndex={selectedIndices.sshKeys}
+          />
+        </Box>
+        <DetailsBar
+          panel={PANELS[selectedPanelIndex] ?? PANELS[0]}
+          deployments={deployments}
+          instances={instances}
+          sshKeys={sshKeys}
+          selectedIndices={selectedIndices}
+        />
+        <MessageLog messages={messages} />
+        <CommandBar commandMode={commandMode} buffer={commandBuffer} />
+      </Box>
+    </Viewport>
+  );
+}
+
+interface PanelViewProps {
+  title: string;
+  summary: string;
+  isActive: boolean;
+  items: string[];
+  selectedIndex: number;
+}
+
+function PanelView({ title, summary, isActive, items, selectedIndex }: PanelViewProps): React.ReactNode {
+  const titleProps = isActive ? { color: 'cyan' as const } : {};
+  return (
+    <Box flexDirection="column" flexGrow={1} borderStyle="round" borderColor={isActive ? 'cyan' : 'gray'} padding={1}>
+      <Text {...titleProps} bold>{title}</Text>
+      <Text dimColor>{summary}</Text>
+      <Box flexDirection="column" marginTop={1} gap={0}>
+        {items.length === 0 ? (
+          <Text dimColor>No entries.</Text>
+        ) : (
+          items.map((item, index) => (
+            <Text
+              key={item}
+              {...(index === selectedIndex && isActive ? { color: 'cyan' as const } : {})}
+            >
+              {index === selectedIndex && isActive ? '› ' : '  '}
+              {item}
+            </Text>
+          ))
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+interface MessageLogProps {
+  messages: Message[];
+}
+
+function MessageLog({ messages }: MessageLogProps): React.ReactNode {
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="gray" padding={1} height={8}>
+      <Text bold>Activity</Text>
+      {messages.slice(-6).map((message, index) => (
+        <Text
+          key={`${message.text}-${index}`}
+          {...(message.level === 'error'
+            ? { color: 'red' as const }
+            : message.level === 'success'
+              ? { color: 'green' as const }
+              : {})}
+        >
+          {message.text}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+interface CommandBarProps {
+  commandMode: boolean;
+  buffer: string;
+}
+
+function CommandBar({ commandMode, buffer }: CommandBarProps): React.ReactNode {
+  return (
+    <Box flexDirection="row" borderStyle="round" borderColor={commandMode ? 'cyan' : 'gray'} paddingX={1} paddingY={0}>
+      <Text {...(commandMode ? { color: 'cyan' as const } : {})}>{commandMode ? ':' : 'Command'}</Text>
+      <Spacer />
+      <Text>{commandMode ? buffer : 'Press : to enter a command'}</Text>
+    </Box>
+  );
+}
+
+interface DetailsBarProps {
+  panel: Panel;
+  deployments: DeploymentProfile[];
+  instances: InstanceDescriptor[];
+  sshKeys: SshKeyMetadata[];
+  selectedIndices: IndexState;
+}
+
+function DetailsBar({ panel, deployments, instances, sshKeys, selectedIndices }: DetailsBarProps): React.ReactNode {
+  let title = 'Details';
+  let lines: string[] = [];
+
+  if (panel === 'deployments') {
+    const deployment = deployments[selectedIndices.deployments];
+    if (deployment) {
+      title = `Deployment ${deployment.name}`;
+      lines = [
+        `Provider: ${deployment.provider}`,
+        `Status: ${deployment.status}`,
+        `Created: ${new Date(deployment.createdAt).toLocaleString()}`,
+        `Last update: ${new Date(deployment.updatedAt).toLocaleString()}`,
+      ];
+    }
+  } else if (panel === 'instances') {
+    const instance = instances[selectedIndices.instances];
+    if (instance) {
+      title = `Instance ${instance.name}`;
+      lines = [
+        `Provider: ${instance.provider}`,
+        `Region: ${instance.region}`,
+        `State: ${instance.state}`,
+        `IP: ${instance.ipAddress ?? 'unknown'}`,
+      ];
+    }
+  } else if (panel === 'sshKeys') {
+    const key = sshKeys[selectedIndices.sshKeys];
+    if (key) {
+      title = `SSH Key ${key.name}`;
+      lines = [
+        `Providers: ${key.providers.join(', ') || 'none'}`,
+        `Fingerprint: ${key.fingerprint ?? 'unknown'}`,
+        `Default for: ${key.defaultFor?.join(', ') ?? 'none'}`,
+      ];
+    }
+  }
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="gray" padding={1}>
+      <Text bold>{title}</Text>
+      {lines.length === 0 ? <Text dimColor>No selection.</Text> : lines.map((line) => <Text key={line}>{line}</Text>)}
+    </Box>
+  );
+}
+
+function formatInstanceRow(instance: InstanceDescriptor): string {
+  const name = instance.name ?? instance.id;
+  const state = instance.state ?? 'unknown';
+  const ip = instance.ipAddress ?? 'pending';
+  return `${name} (${instance.provider}) - ${state} @ ${ip}`;
+}
+
+function formatKeyRow(key: SshKeyMetadata): string {
+  return `${key.name} [${key.providers.join(', ')}]`;
+}
+
+function clampIndex(index: number, length: number): number {
+  if (length === 0) {
+    return 0;
+  }
+  if (index >= length) {
+    return length - 1;
+  }
+  if (index < 0) {
+    return 0;
+  }
+  return index;
+}
+
+function getPanelLength(
+  panel: Panel,
+  deployments: DeploymentProfile[],
+  instances: InstanceDescriptor[],
+  sshKeys: SshKeyMetadata[],
+): number {
+  switch (panel) {
+    case 'deployments':
+      return deployments.length;
+    case 'instances':
+      return instances.length;
+    case 'sshKeys':
+      return sshKeys.length;
+    default:
+      return 0;
+  }
+}
+
+function buildConfiguration(options: Record<string, string | boolean>): Record<string, unknown> {
+  const configuration: Record<string, unknown> = {};
+  const skipKeys = new Set(['provider', 'p', 'name', 'n', 'key', 'providers', 'public', 'private', 'default-for']);
+  for (const [rawKey, rawValue] of Object.entries(options)) {
+    if (skipKeys.has(rawKey)) {
+      continue;
+    }
+    const value = parseValue(rawValue);
+    if (rawKey.startsWith('config.')) {
+      configuration[rawKey.slice('config.'.length)] = value;
+      continue;
+    }
+    const camelKey = rawKey.replace(/-([a-z])/g, (_match, char: string) => char.toUpperCase());
+    configuration[camelKey] = value;
+  }
+  return configuration;
+}
+
+function parseValue(value: string | boolean): unknown {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  const numeric = Number(value);
+  if (!Number.isNaN(numeric) && value.trim() !== '') {
+    return numeric;
+  }
+  if (value.includes(',')) {
+    return value.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+  return value;
+}
+
+export default App;

--- a/src/utils/commandParser.ts
+++ b/src/utils/commandParser.ts
@@ -1,0 +1,83 @@
+export interface ParsedCommand {
+  command: string;
+  args: string[];
+  options: Record<string, string | boolean>;
+}
+
+export function parseCommandLine(input: string): ParsedCommand | undefined {
+  const tokens = tokenize(input.trim());
+  if (tokens.length === 0) {
+    return undefined;
+  }
+  const command = tokens[0]!;
+  const rest = tokens.slice(1);
+  const args: string[] = [];
+  const options: Record<string, string | boolean> = {};
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (!token) {
+      continue;
+    }
+    if (token.startsWith('--')) {
+      const keyValue = token.slice(2);
+      if (keyValue.includes('=')) {
+        const [key, value = ''] = keyValue.split(/=(.+)/);
+        if (key) {
+          options[key] = value;
+        }
+      } else {
+        const nextToken = rest[index + 1];
+        if (nextToken && !nextToken.startsWith('--')) {
+          options[keyValue] = nextToken;
+          index += 1;
+        } else {
+          options[keyValue] = true;
+        }
+      }
+    } else {
+      args.push(token);
+    }
+  }
+
+  return { command, args, options };
+}
+
+function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  let quoteChar: string | undefined;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i]!;
+
+    if ((char === '"' || char === "'") && !inQuotes) {
+      inQuotes = true;
+      quoteChar = char;
+      continue;
+    }
+
+    if (inQuotes && char === quoteChar) {
+      inQuotes = false;
+      quoteChar = undefined;
+      continue;
+    }
+
+    if (!inQuotes && /\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-console */
+export const logger = {
+  info: (message: string) => console.log(`[INFO] ${message}`),
+  warn: (message: string) => console.warn(`[WARN] ${message}`),
+  error: (message: string, error?: unknown) => {
+    if (error instanceof Error) {
+      console.error(`[ERROR] ${message}: ${error.message}`);
+      if (error.stack) {
+        console.error(error.stack);
+      }
+    } else if (error) {
+      console.error(`[ERROR] ${message}:`, error);
+    } else {
+      console.error(`[ERROR] ${message}`);
+    }
+  },
+  debug: (message: string) => {
+    if (process.env.DEBUG) {
+      console.debug(`[DEBUG] ${message}`);
+    }
+  },
+};

--- a/src/utils/ssh.ts
+++ b/src/utils/ssh.ts
@@ -1,0 +1,57 @@
+import crypto from 'crypto';
+import { promises as fs } from 'fs';
+import { spawn } from 'child_process';
+
+export async function calculateFingerprint(publicKeyPath: string): Promise<string | undefined> {
+  try {
+    const fingerprint = await runSshKeygenFingerprint(publicKeyPath);
+    if (fingerprint) {
+      return fingerprint;
+    }
+  } catch {
+    // ignore, fall back to manual calculation
+  }
+
+  try {
+    const contents = await fs.readFile(publicKeyPath, 'utf-8');
+    const keyParts = contents.trim().split(' ');
+    const base64 = keyParts[1];
+    if (!base64) {
+      return undefined;
+    }
+    const decoded = Buffer.from(base64, 'base64');
+    const hash = crypto.createHash('md5').update(decoded).digest('hex');
+    return hash.match(/.{1,2}/g)?.join(':');
+  } catch {
+    return undefined;
+  }
+}
+
+async function runSshKeygenFingerprint(publicKeyPath: string): Promise<string | undefined> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('ssh-keygen', ['-lf', publicKeyPath]);
+    let output = '';
+    let errorOutput = '';
+
+    child.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      errorOutput += data.toString();
+    });
+
+    child.on('error', reject);
+
+    child.on('close', (code) => {
+      if (code === 0 && output) {
+        const fingerprint = output.split(' ')[1];
+        resolve(fingerprint);
+      } else if (errorOutput) {
+        reject(new Error(errorOutput));
+      } else {
+        resolve(undefined);
+      }
+    });
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,45 @@
+{
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    // File Layout
+    "rootDir": "src",
+    "outDir": "dist",
+
+    // Environment Settings
+    // See also https://aka.ms/tsconfig/module
+    "module": "NodeNext",
+    "target": "es2020",
+    "moduleResolution": "node16",
+    "types": ["node"],
+    // For nodejs:
+    // "lib": ["esnext"],
+    // "types": ["node"],
+    // and npm install -D @types/node
+
+    // Other Outputs
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Style Options
+    // "noImplicitReturns": true,
+    // "noImplicitOverride": true,
+    // "noUnusedLocals": true,
+    // "noUnusedParameters": true,
+    // "noFallthroughCasesInSwitch": true,
+    // "noPropertyAccessFromIndexSignature": true,
+
+    // Recommended Options
+    "strict": true,
+    "jsx": "react-jsx",
+    "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}


### PR DESCRIPTION
## Summary
- add an architecture plan describing the multi-cloud deployment TUI scope
- implement a React+tuir terminal UI with command palette workflows for managing keys, deployments, and instances
- scaffold provider adapters and persistence services for AWS, GCP, Azure, and DigitalOcean using a shared configuration store

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0cbe6e49c8333b8c8052710d2901d